### PR TITLE
Support poetry export

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Removes a dependency from the specified project, updates the shared lockfile, an
 
 Builds the **current** project, replacing editable path dependencies with the current version of the package. This is useful when building a project that depends on another project in the monorepo, as it ensures that the built package can be installed (e.g. as a wheel file) without expecting the other project to be present in a specific location.
 
+- `poetry export`:
+
+Exports the dependencies from the shared lock file (located at the root).
+
 
 ### Configuration
 The plugin can be configured in the `pyproject.toml` file of each project. The following options are available:

--- a/poetry_monoranger_plugin/plugin.py
+++ b/poetry_monoranger_plugin/plugin.py
@@ -22,6 +22,11 @@ from poetry.console.commands.self.self_command import SelfCommand
 from poetry.console.commands.update import UpdateCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
 
+try:
+    from poetry_plugin_export.command import ExportCommand
+except:
+    ExportCommand = None
+
 from poetry_monoranger_plugin.config import MonorangerConfig
 
 if TYPE_CHECKING:
@@ -103,7 +108,7 @@ class Monoranger(ApplicationPlugin):
 
             VenvModifier(self.plugin_conf).execute(event)
 
-        if isinstance(command, (LockCommand, InstallCommand, UpdateCommand)):
+        if isinstance(command, (LockCommand, InstallCommand, UpdateCommand, ExportCommand)):
             from poetry_monoranger_plugin.lock_modifier import LockModifier
 
             # NOTE: consider moving this to a separate UpdateModifier class


### PR DESCRIPTION
This implementation simply exports all dependencies from the root lockfile. A more refined implementation could select only the relevant dependencies for a particular project.

Implements the simple solution from #28 