### PR TITLE
Pass optional and extras specification to rewritten dependencies

### DIFF
--- a/poetry_monoranger_plugin/path_rewriter.py
+++ b/poetry_monoranger_plugin/path_rewriter.py
@@ -97,4 +97,10 @@ class PathRewriter:
         else:
             raise ValueError(f"Invalid version rewrite rule: {self.plugin_conf.version_rewrite_rule}")
 
-        return Dependency(name, pinned_version, groups=dependency.groups)
+        return Dependency(
+            name,
+            pinned_version,
+            groups=dependency.groups,
+            optional=dependency.is_optional(),
+            extras=dependency.extras,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.dependency_group import DependencyGroup
+from poetry.core.packages.dependency_group import MAIN_GROUP, DependencyGroup
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.poetry import Poetry
 
@@ -15,9 +15,18 @@ def mock_event_gen():
     def _factory(command_cls: type[Command], disable_cache: bool):
         from cleo.events.console_command_event import ConsoleCommandEvent
 
-        main_grp = DependencyGroup("main")
-        main_grp.add_dependency(DirectoryDependency("packageB", Path("../packageB"), develop=True))
+        main_grp = DependencyGroup(MAIN_GROUP)
         main_grp.add_dependency(Dependency("numpy", "==1.5.0"))
+        main_grp.add_dependency(
+            DirectoryDependency(
+                "packageB",
+                Path("../packageB"),
+                develop=True,
+                groups=[main_grp.name],
+                optional=True,
+                extras=["fast"],
+            )
+        )
 
         mock_command = Mock(spec=command_cls)
         mock_command.poetry = Mock(spec=Poetry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ def mock_event_gen():
                 "packageB",
                 Path("../packageB"),
                 develop=True,
-                groups=[main_grp.name],
                 optional=True,
                 extras=["fast"],
             )

--- a/tests/test_path_rewriter.py
+++ b/tests/test_path_rewriter.py
@@ -35,6 +35,8 @@ def test_executes_path_rewriting_for_build_command(mock_event_gen, disable_cache
     new_dependencies = sorted(new_dependencies.dependencies, key=lambda x: x.name)
     for i, dep in enumerate(new_dependencies):
         assert dep.name == original_dependencies[i].name
+        assert dep.is_optional() == original_dependencies[i].is_optional()
+        assert dep.extras == original_dependencies[i].extras
         if isinstance(original_dependencies[i], DirectoryDependency):
             assert dep.pretty_constraint == "0.1.0"
         else:


### PR DESCRIPTION
Hi, thanks very much for developing this plugin. The shared lock file is precisely what I need for the monorepo I am working on (https://github.com/DTOcean/dtocean/tree/next).

I would like to be able to include some path dependencies as [extras](https://python-poetry.org/docs/pyproject/#extras) and those dependencies might also require their own [dependency extras](https://python-poetry.org/docs/dependency-specification/#dependency-extras) to be defined.

This PR, then, copies the `optional` and `extras` configuration to the rewritten dependencies.