### PR TITLE
Support `[tool.poetry]` being used with PEP-621

### DIFF
--- a/poetry_monoranger_plugin/path_dep_pinner.py
+++ b/poetry_monoranger_plugin/path_dep_pinner.py
@@ -132,7 +132,7 @@ class PathDepPinner:
         try:
             name = cast(str, dep_pyproject.poetry_config["name"])
             version = cast(str, dep_pyproject.poetry_config["version"])
-        except PyProjectError:
+        except (PyProjectError, KeyError):
             # Fallback to the project section since Poetry V2 also supports PEP 621 pyproject.toml files
             name = cast(str, dep_pyproject.data["project"]["name"])
             version = cast(str, dep_pyproject.data["project"]["version"])

--- a/tests/fixtures/v2/pkg_two/pyproject.toml
+++ b/tests/fixtures/v2/pkg_two/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "tqdm (>=4.67.1,<5.0.0)"
 ]
 
+[tool.poetry]
+requires-poetry = ">=2.0.0,<3.0.0"
+
 [tool.poetry-monoranger-plugin]
 enabled = true
 monorepo-root = "../"


### PR DESCRIPTION
`[tool.poetry]` section can co-exist with a PEP-621 styled project metadata to provide extra information. In `_pin_dependency` missing `name` and `version` keys inside a `poetry_config` raises `KeyError`s which aren't caught and leads to a fatal error.